### PR TITLE
T 0008

### DIFF
--- a/src/main/java/com/socialmeli/socialmeli/services/PostService.java
+++ b/src/main/java/com/socialmeli/socialmeli/services/PostService.java
@@ -12,10 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 @Service
 public class PostService implements IPostService{
@@ -60,13 +57,18 @@ public class PostService implements IPostService{
 
     @Override
     public UserFollowedPostsDto getLastTwoWeeksFollowedPosts(Integer userId, List<UserDto> followedList, String order){
-        if(postRepository.findById(userId).isEmpty())
-            throw new NotFoundException("No se encontraron post del usuario " + userId);
+        if(followedList.isEmpty()){
+            throw new NotFoundException("El usuario " + userId + " no sigue a otro usuarios");
+        }
 
         List<PostDto> allFollowedPosts = new ArrayList<>();
 
         for (UserDto userDto : followedList){
-            allFollowedPosts.addAll(this.getUserPosts(userDto.user_id()));
+            allFollowedPosts.addAll( this.getUserPosts(userDto.user_id()));
+        }
+
+        if(allFollowedPosts.isEmpty()){
+            throw new NotFoundException("No se encontraron post para los usuarios que sigue el usuario " + userId);
         }
 
         LocalDate currentDate = LocalDate.now();

--- a/src/main/java/com/socialmeli/socialmeli/services/PostService.java
+++ b/src/main/java/com/socialmeli/socialmeli/services/PostService.java
@@ -67,14 +67,14 @@ public class PostService implements IPostService{
             allFollowedPosts.addAll(this.getUserPosts(userDto.userId()));
         }
 
-        if(allFollowedPosts.isEmpty()){
-            throw new NotFoundException("No se encontraron post para los usuarios que sigue el usuario " + userId);
+        LocalDate currentDate = LocalDate.now();
+        allFollowedPosts = sortLastFollowedPost(allFollowedPosts.stream().filter(post -> ChronoUnit.DAYS.between(post.date(),currentDate)<=14).toList(), order);
 
+        if(allFollowedPosts.isEmpty()){
+            throw new NotFoundException("No se encontraron post recientes de los usuarios que sigue el usuario " + userId);
         }
 
-        LocalDate currentDate = LocalDate.now();
-
-        return new UserFollowedPostsDto(userId, sortLastFollowedPost(allFollowedPosts.stream().filter(post -> ChronoUnit.DAYS.between(post.date(),currentDate)<=14).toList(), order)) ;
+        return new UserFollowedPostsDto(userId, allFollowedPosts) ;
     }
 
     public List<PostDto> sortLastFollowedPost(List<PostDto> posts, String order){

--- a/src/main/resources/json/user.json
+++ b/src/main/resources/json/user.json
@@ -38,10 +38,6 @@
       }],
     "followed": [
       {
-        "user_id": 234,
-        "user_name": "usuario4"
-      },
-      {
         "user_id": 1465,
         "user_name": "usuario1"
       },

--- a/src/test/java/com/socialmeli/socialmeli/unit/controller/SocialControllerTest.java
+++ b/src/test/java/com/socialmeli/socialmeli/unit/controller/SocialControllerTest.java
@@ -1,0 +1,69 @@
+package com.socialmeli.socialmeli.unit.controller;
+
+import com.socialmeli.socialmeli.controller.SocialController;
+import com.socialmeli.socialmeli.dto.*;
+import com.socialmeli.socialmeli.services.PostService;
+import com.socialmeli.socialmeli.services.UserService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+public class SocialControllerTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private PostService postService;
+
+    @InjectMocks
+    private SocialController socialController;
+
+    @Test
+    @DisplayName("getLastTwoWeeksFollowedPosts: should return a status code ok")
+    public void getLastTwoWeeksFollowedPosts(){
+        //Arrange
+        Integer userId = 4698;
+        String order = "name_asc";
+
+        //Act
+        List<UserDto> followedList = List.of(
+                new UserDto(1465, "usuario1"),
+                new UserDto(234, "usuario4"),
+                new UserDto(123, "usuario5")
+        );
+
+        UserFollowedDto userFollowedList = new UserFollowedDto(
+                4698,
+                "usuario2",
+                List.of(
+                    new UserDto(1465, "usuario1"),
+                    new UserDto(234, "usuario4"),
+                    new UserDto(123, "usuario5")
+        ));
+
+        var expected = new UserFollowedPostsDto(123, List.of(new  PostDto(234,
+                LocalDate.of(2024, 01, 16),
+                new ProductDto(7, "Mochila", "", "Everlast", "Blue", "Permite Notebook"),
+                100,
+                8000.50)));
+
+        Mockito.when(userService.listFollowed(userId, order)).thenReturn(userFollowedList);
+        Mockito.when(postService.getLastTwoWeeksFollowedPosts(userId, followedList, order)).thenReturn(expected);
+        var result = socialController.getLastTwoWeeksFollowedPosts(userId, order);
+
+        //Assert
+        Assertions.assertEquals(HttpStatus.OK, result.getStatusCode());
+
+    }
+}

--- a/src/test/java/com/socialmeli/socialmeli/unit/service/PostServiceTest.java
+++ b/src/test/java/com/socialmeli/socialmeli/unit/service/PostServiceTest.java
@@ -1,0 +1,108 @@
+package com.socialmeli.socialmeli.unit.service;
+
+import com.socialmeli.socialmeli.dto.PostDto;
+import com.socialmeli.socialmeli.dto.ProductDto;
+import com.socialmeli.socialmeli.dto.UserDto;
+import com.socialmeli.socialmeli.dto.UserFollowedPostsDto;
+import com.socialmeli.socialmeli.entities.Post;
+import com.socialmeli.socialmeli.entities.Product;
+import com.socialmeli.socialmeli.mapper.Mapper;
+import com.socialmeli.socialmeli.repositories.PostRepositoryImpl;
+import com.socialmeli.socialmeli.services.PostService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+@ExtendWith(MockitoExtension.class)
+public class PostServiceTest {
+
+    @Mock
+    PostRepositoryImpl postRepository;
+
+    @Mock
+    Mapper mapper;
+
+    @InjectMocks
+    private PostService postService;
+
+    // Constantes
+    Post postId1 = new Post(1465,
+            1,
+            LocalDate.of(2024, 01, 02),
+            new Product(1, "Silla Gamer", "Gamer", "Racer", "Red & Black", "Special Edition"),
+            100,
+            1500.50);
+
+    Post postId2 = new Post(1465,
+            2,
+            LocalDate.of(2023, 12, 30),
+            new Product(1, "Headset RGB Inalámbrico", "Gamer", "Razer", "Green with RGB", "Sin Batería"),
+            100,
+            1500.50);
+
+    Post postId7 = new Post(234,
+            7,
+            LocalDate.of(2024, 01, 16),
+            new Product(7, "Mochila", "", "Everlast", "Blue", "Permite Notebook"),
+            100,
+            8000.50);
+
+    PostDto postDtoId1 = new PostDto(1465,
+            LocalDate.of(2024, 01, 02),
+            new ProductDto(1, "Silla Gamer", "Gamer", "Racer", "Red & Black", "Special Edition"),
+            100,
+            1500.50);
+
+    PostDto postDtoId2 = new PostDto(1465,
+            LocalDate.of(2023, 12, 30),
+            new ProductDto(1, "Headset RGB Inalámbrico", "Gamer", "Razer", "Green with RGB", "Sin Batería"),
+            100,
+            1500.50);
+
+    PostDto postDtoId7 = new PostDto(234,
+            LocalDate.of(2024, 01, 16),
+            new ProductDto(7, "Mochila", "", "Everlast", "Blue", "Permite Notebook"),
+            100,
+            8000.50);
+
+
+    @Test
+    @DisplayName("getLastTwoWeeksFollowedPosts: should return UserFollowedPostsDto")
+    public void getLastTwoWeeksFollowedPosts(){
+        //Arrange
+        Integer userId = 4698;
+        String order = "date_desc";
+        List<UserDto> followedList = List.of(
+                new UserDto(1465, "usuario1"),
+                new UserDto(234, "usuario4"),
+                new UserDto(123, "usuario5")
+        );
+
+        ArrayList<Post> allPosts = new ArrayList<>(Arrays.asList(postId1, postId2, postId7));
+
+        List<PostDto> posts = List.of(postDtoId7);
+
+        UserFollowedPostsDto expected = new UserFollowedPostsDto(userId, posts);
+
+        //Act
+        Mockito.when(this.postRepository.findAll()).thenReturn(allPosts);
+        Mockito.when(mapper.convertPostToDto(postId1)).thenReturn(postDtoId1);
+        Mockito.when(mapper.convertPostToDto(postId2)).thenReturn(postDtoId2);
+        Mockito.when(mapper.convertPostToDto(postId7)).thenReturn(postDtoId7);
+        var result = postService.getLastTwoWeeksFollowedPosts(userId, followedList, order);
+
+        //Assert
+        Assertions.assertEquals(expected, result);
+    }
+}

--- a/src/test/java/com/socialmeli/socialmeli/unit/service/PostServiceTest.java
+++ b/src/test/java/com/socialmeli/socialmeli/unit/service/PostServiceTest.java
@@ -6,6 +6,7 @@ import com.socialmeli.socialmeli.dto.UserDto;
 import com.socialmeli.socialmeli.dto.UserFollowedPostsDto;
 import com.socialmeli.socialmeli.entities.Post;
 import com.socialmeli.socialmeli.entities.Product;
+import com.socialmeli.socialmeli.exceptions.NotFoundException;
 import com.socialmeli.socialmeli.mapper.Mapper;
 import com.socialmeli.socialmeli.repositories.PostRepositoryImpl;
 import com.socialmeli.socialmeli.services.PostService;
@@ -104,5 +105,33 @@ public class PostServiceTest {
 
         //Assert
         Assertions.assertEquals(expected, result);
+    }
+
+    @Test
+    @DisplayName("getLastTwoWeeksFollowedPosts: should return NotFoundException when followedList is empty")
+    public void followedListEmptyGetLastTwoWeeksFollowedPosts(){
+        //Arrange
+        Integer userId = 234;
+        String order = "date_desc";
+        List<UserDto> followedList = new ArrayList<>();
+
+        //Assert
+        Assertions.assertThrows(NotFoundException.class, () ->{
+            postService.getLastTwoWeeksFollowedPosts(userId, followedList, order);
+        });
+    }
+
+    @Test
+    @DisplayName("getLastTwoWeeksFollowedPosts: should return NotFoundException when allFollowedPosts is empty")
+    public void allFollowedPostsEmptyGetLastTwoWeeksFollowedPosts(){
+        //Arrange
+        Integer userId = 4698;
+        String order = "date_desc";
+        List<UserDto> followedList = new ArrayList<>();
+
+        //Assert
+        Assertions.assertThrows(NotFoundException.class, () ->{
+            postService.getLastTwoWeeksFollowedPosts(userId, followedList, order);
+        });
     }
 }


### PR DESCRIPTION
![image](https://github.com/cgalezo-meli/be_java_hisp_w24_g03/assets/154446631/4c5c2d4a-acfa-45ba-ac13-4df7ded8889b)

Se agregan test unitarios para método getLastTwoWeeksFollowedPosts (US_0006):
- getLastTwoWeeksFollowedPosts (service): T-0008
- followedListEmptyGetLastTwoWeeksFollowedPosts: verifica excepción cuando no hay usuarios seguidos
- allFollowedPostsEmptyGetLastTwoWeeksFollowedPosts: verifica excepción cuando no hay post recientes
- getLastTwoWeeksFollowedPosts (controller)

Se modifica user.json, quitando al user_id 4698 el usuario 234 en followed
Se realiza refactorización del método getLastTwoWeeksFollowedPosts (PostService) para que funcione correctamente la excepción